### PR TITLE
chore: update client_documentation link

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "translation",
   "name_pretty": "Cloud Translation",
   "product_documentation": "https://cloud.google.com/translate/docs/",
-  "client_documentation": "https://googleapis.dev/java/java-translate/latest/index.html",
+  "client_documentation": "https://googleapis.dev/java/google-cloud-clients/latest/index.html?com/google/cloud/translate/package-summary.html",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559749",
   "release_level": "ga",
   "language": "java",


### PR DESCRIPTION
The current link is 404ing, so I used the same link found in the README. Let me know if you'd prefer something else :).