### PR TITLE
fix: extend timeout on batch translation requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:22.0.0')
+implementation platform('com.google.cloud:libraries-bom:23.0.0')
 
 implementation 'com.google.cloud:google-cloud-translate'
 ```

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-translate'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-translate:2.0.6'
+implementation 'com.google.cloud:google-cloud-translate:2.1.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-translate" % "2.0.6"
+libraryDependencies += "com.google.cloud" % "google-cloud-translate" % "2.1.0"
 ```
 
 ## Authentication

--- a/samples/snippets/src/main/java/com/example/translate/BatchTranslateText.java
+++ b/samples/snippets/src/main/java/com/example/translate/BatchTranslateText.java
@@ -88,7 +88,7 @@ public class BatchTranslateText {
       System.out.println("Waiting for operation to complete...");
 
       // random number between 300 - 450 (maximum allowed seconds)
-      long randomNumber = ThreadLocalRandom.current().nextInt(300, 450);
+      long randomNumber = ThreadLocalRandom.current().nextInt(450, 600);
       BatchTranslateResponse response = future.get(randomNumber, TimeUnit.SECONDS);
 
       System.out.printf("Total Characters: %s\n", response.getTotalCharacters());

--- a/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithGlossary.java
+++ b/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithGlossary.java
@@ -106,7 +106,7 @@ public class BatchTranslateTextWithGlossary {
       System.out.println("Waiting for operation to complete...");
 
       // random number between 300 - 450 (maximum allowed seconds)
-      long randomNumber = ThreadLocalRandom.current().nextInt(300, 450);
+      long randomNumber = ThreadLocalRandom.current().nextInt(450, 600);
       BatchTranslateResponse response = future.get(randomNumber, TimeUnit.SECONDS);
 
       // Display the translation for each input text provided

--- a/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithGlossaryAndModel.java
+++ b/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithGlossaryAndModel.java
@@ -113,7 +113,7 @@ public class BatchTranslateTextWithGlossaryAndModel {
       System.out.println("Waiting for operation to complete...");
 
       // random number between 300 - 450 (maximum allowed seconds)
-      long randomNumber = ThreadLocalRandom.current().nextInt(300, 450);
+      long randomNumber = ThreadLocalRandom.current().nextInt(450, 600);
       BatchTranslateResponse response = future.get(randomNumber, TimeUnit.SECONDS);
 
       // Display the translation for each input text provided

--- a/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithModel.java
+++ b/samples/snippets/src/main/java/com/example/translate/BatchTranslateTextWithModel.java
@@ -103,7 +103,7 @@ public class BatchTranslateTextWithModel {
       System.out.println("Waiting for operation to complete...");
 
       // random number between 300 - 450 (maximum allowed seconds)
-      long randomNumber = ThreadLocalRandom.current().nextInt(300, 450);
+      long randomNumber = ThreadLocalRandom.current().nextInt(450, 600);
       BatchTranslateResponse response = future.get(randomNumber, TimeUnit.SECONDS);
 
       // Display the translation for each input text provided


### PR DESCRIPTION
This PR extends the amount of time that the samples wait for the batch translation requests to return by 450-600 seconds.

Fixes #613 ,  #624 , #566 ☕️
