### PR TITLE
test: Update batch translate tests to minimize flakiness

### DIFF
--- a/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextTests.java
+++ b/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextTests.java
@@ -46,8 +46,6 @@ public class BatchTranslateTextTests {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String INPUT_URI = "gs://cloud-samples-data/translation/text.txt";
   private static final String PREFIX = "BATCH_TRANSLATION_OUTPUT_";
-  private static final String OUTPUT_URI =
-      String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
@@ -115,8 +113,8 @@ public class BatchTranslateTextTests {
   @Test
   public void testBatchTranslateText()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
-    BatchTranslateText.batchTranslateText(PROJECT_ID, "en", "es", INPUT_URI, OUTPUT_URI);
-
+    String outputUri = String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
+    BatchTranslateText.batchTranslateText(PROJECT_ID, "en", "es", INPUT_URI, outputUri);
     String got = bout.toString();
     assertThat(got).contains("Total Characters: 13");
   }

--- a/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithGlossaryAndModelTests.java
+++ b/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithGlossaryAndModelTests.java
@@ -49,8 +49,6 @@ public class BatchTranslateTextWithGlossaryAndModelTests {
   private static final String GLOSSARY_ID = "DO_NOT_DELETE_TEST_GLOSSARY";
   private static final String MODEL_ID = "TRL3645318651705294848";
   private static final String PREFIX = "BATCH_TRANSLATION_MODEL_GLOS_OUTPUT_";
-  private static final String OUTPUT_URI =
-      String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
@@ -121,8 +119,9 @@ public class BatchTranslateTextWithGlossaryAndModelTests {
   @Test
   public void testBatchTranslateTextWithGlossaryAndModel()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
+    String outputUri = String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
     BatchTranslateTextWithGlossaryAndModel.batchTranslateTextWithGlossaryAndModel(
-        PROJECT_ID, "en", "ja", INPUT_URI, OUTPUT_URI, GLOSSARY_ID, MODEL_ID);
+        PROJECT_ID, "en", "ja", INPUT_URI, outputUri, GLOSSARY_ID, MODEL_ID);
     String got = bout.toString();
     assertThat(got).contains("Total Characters: 25");
   }

--- a/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithGlossaryTests.java
+++ b/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithGlossaryTests.java
@@ -48,8 +48,6 @@ public class BatchTranslateTextWithGlossaryTests {
       "gs://cloud-samples-data/translation/text_with_glossary.txt";
   private static final String GLOSSARY_ID = "DO_NOT_DELETE_TEST_GLOSSARY";
   private static final String PREFIX = "BATCH_TRANSLATION_GLOSSARY_OUTPUT_";
-  private static final String OUTPUT_URI =
-      String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
@@ -120,8 +118,9 @@ public class BatchTranslateTextWithGlossaryTests {
   @Test
   public void testBatchTranslateTextWithGlossary()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
+    String outputUri = String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
     BatchTranslateTextWithGlossary.batchTranslateTextWithGlossary(
-        PROJECT_ID, "en", "ja", INPUT_URI, OUTPUT_URI, GLOSSARY_ID);
+        PROJECT_ID, "en", "ja", INPUT_URI, outputUri, GLOSSARY_ID);
     String got = bout.toString();
     assertThat(got).contains("Total Characters: 9");
   }

--- a/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithModelTests.java
+++ b/samples/snippets/src/test/java/com/example/translate/BatchTranslateTextWithModelTests.java
@@ -48,8 +48,6 @@ public class BatchTranslateTextWithModelTests {
       "gs://cloud-samples-data/translation/custom_model_text.txt";
   private static final String MODEL_ID = "TRL3645318651705294848";
   private static final String PREFIX = "BATCH_TRANSLATION_WITH_MODEL_OUTPUT_";
-  private static final String OUTPUT_URI =
-      String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
@@ -116,8 +114,9 @@ public class BatchTranslateTextWithModelTests {
   @Test
   public void testBatchTranslateTextWithModel()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
+    String outputUri = String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
     BatchTranslateTextWithModel.batchTranslateTextWithModel(
-        PROJECT_ID, "en", "ja", INPUT_URI, OUTPUT_URI, MODEL_ID);
+        PROJECT_ID, "en", "ja", INPUT_URI, outputUri, MODEL_ID);
     String got = bout.toString();
     assertThat(got).contains("Total Characters: 15");
   }

--- a/samples/snippets/src/test/java/com/example/translatev3beta1/BatchTranslateDocumentTests.java
+++ b/samples/snippets/src/test/java/com/example/translatev3beta1/BatchTranslateDocumentTests.java
@@ -45,8 +45,6 @@ public class BatchTranslateDocumentTests {
   private static final String INPUT_URI =
       "gs://java-docs-samples-testing/translation/invoice2.docx";
   private static final String PREFIX = "BATCH_DOC_TRANSLATION_OUTPUT_";
-  private static final String OUTPUT_URI =
-      String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
@@ -109,8 +107,9 @@ public class BatchTranslateDocumentTests {
   @Test
   public void testBatchTranslateDocument()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
+    String outputUri = String.format("gs://%s/%s%s/", PROJECT_ID, PREFIX, UUID.randomUUID());
     BatchTranslateDocument.batchTranslateDocument(
-        PROJECT_ID, "en-US", "fr-FR", INPUT_URI, OUTPUT_URI, 1000);
+        PROJECT_ID, "en-US", "fr-FR", INPUT_URI, outputUri, 1000);
 
     String got = bout.toString();
     assertThat(got).contains("Total Pages:");


### PR DESCRIPTION
We added retries to the batch translate tests recently. However, any retry will fail due to the path already existing. This update uses a new UUID in the test method to ensure that retries work properly.

Fixes #813, #624  ☕️
